### PR TITLE
Fix missing types in signatures

### DIFF
--- a/src/api.typ
+++ b/src/api.typ
@@ -125,7 +125,7 @@
     d = doc("introspection/" + type, fnote:fnote)
   } else if type in ("angle", "direction", "fraction", "length", "ratio", "relative") {
     d = doc("layout/" + type, fnote:fnote)
-	} else if type in ("array", "bool", "content", "dictionary", "duration", "float", "function", "int", "label", "regex", "str", "version") {
+	} else if type in ("array", "bool", "bytes", "content", "datetime", "dictionary", "duration", "float", "function", "int", "label", "plugin", "regex", "selector", "str", "type", "version") {
 		d = doc("foundations/" + type, fnote:fnote)
 	} else if type in ("color", "sroke") {
 		d = doc("visualize/" + type, fnote:fnote)

--- a/src/api.typ
+++ b/src/api.typ
@@ -127,7 +127,7 @@
     d = doc("layout/" + type, fnote:fnote)
 	} else if type in ("array", "bool", "bytes", "content", "datetime", "dictionary", "duration", "float", "function", "int", "label", "plugin", "regex", "selector", "str", "type", "version") {
 		d = doc("foundations/" + type, fnote:fnote)
-	} else if type in ("color", "sroke") {
+	} else if type in ("color", "stroke") {
 		d = doc("visualize/" + type, fnote:fnote)
 	} else {
 		d = raw(type)

--- a/src/api.typ
+++ b/src/api.typ
@@ -106,7 +106,7 @@
   // some type mappings
   if is.str(type) {
     type = (
-      "integer": "int", "boolean": "bool", "dict": "dictionary", "arr": "array"
+      "integer": "int", "boolean": "bool", "dict": "dictionary", "arr": "array", "string": "str"
     ).at(type, default:type)
   }
 

--- a/src/api.typ
+++ b/src/api.typ
@@ -125,7 +125,7 @@
     d = doc("introspection/" + type, fnote:fnote)
   } else if type in ("angle", "direction", "fraction", "length", "ratio", "relative") {
     d = doc("layout/" + type, fnote:fnote)
-	} else if type in ("array", "bool", "dictionary", "duration", "float", "function", "int", "label", "regex", "str", "version") {
+	} else if type in ("array", "bool", "content", "dictionary", "duration", "float", "function", "int", "label", "regex", "str", "version") {
 		d = doc("foundations/" + type, fnote:fnote)
 	} else if type in ("color", "sroke") {
 		d = doc("visualize/" + type, fnote:fnote)

--- a/src/api.typ
+++ b/src/api.typ
@@ -129,6 +129,8 @@
 		d = doc("foundations/" + type, fnote:fnote)
 	} else if type in ("color", "sroke") {
 		d = doc("visualize/" + type, fnote:fnote)
+	} else {
+		d = raw(type)
 	}
 
 	if type in theme.colors.dtypes {

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -62,7 +62,7 @@
 		"2d alignment": rgb(239, 240, 243),
 		bool: rgb(255, 236, 193),
 		content: rgb(166, 235, 229),
-		string: rgb(209, 255, 226),
+		str: rgb(209, 255, 226),
 		function: rgb(249, 223, 255),
     label: rgb(167, 234, 255),
     color: gradient.linear(..color.map.spectral, angle:180deg),

--- a/src/theme.typ
+++ b/src/theme.typ
@@ -42,6 +42,7 @@
 
   // Datatypes taken from typst.app
 	dtypes: (
+		type: rgb(239, 240, 243),
 		length: rgb(230, 218, 255),
 		int: rgb(230, 218, 255),
 		float: rgb(230, 218, 255),
@@ -54,10 +55,13 @@
 		"auto": rgb(255, 203, 195),
 		"any": rgb(255, 203, 195),
 		"regular expression": rgb(239, 240, 243),
+		arguments: rgb(239, 240, 243),
 		dictionary: rgb(239, 240, 243),
 		array: rgb(239, 240, 243),
+		bytes: rgb(239, 240, 243),
 		stroke: rgb(239, 240, 243),
 		location: rgb(239, 240, 243),
+		selector: rgb(239, 240, 243),
 		alignment: rgb(239, 240, 243),
 		"2d alignment": rgb(239, 240, 243),
 		bool: rgb(255, 236, 193),
@@ -67,6 +71,8 @@
     label: rgb(167, 234, 255),
     color: gradient.linear(..color.map.spectral, angle:180deg),
     gradient: gradient.linear(..color.map.spectral, angle:180deg),
+		plugin: rgb(239, 240, 243),
+		datetime: rgb(239, 240, 243),
 		// color: (
 		// 	rgb(133, 221, 244),
 		// 	rgb(170, 251, 198),


### PR DESCRIPTION
Resolves #9 by adding a missing else branch for types that have no Typst documentation links.

I'm not sure if this is actually correct, it seemed that some types were missing even when they had a Typst docs link, so the type map was not complete.