### PR TITLE
Fix unbalanced module outlines

### DIFF
--- a/src/mty-tidy.typ
+++ b/src/mty-tidy.typ
@@ -49,7 +49,7 @@
 
   if items != () {
     let cols_num = 3
-    let per_col = calc.max(calc.quo(items.len(), cols_num), 1)
+    let per_col = calc.ceil(items.len() / cols_num)
     let cols = ()
     for i in range(items.len(), step:per_col) {
       cols.push(


### PR DESCRIPTION
Adjusts the layout of module outlines to account for unbalanced lengths.

![image](https://github.com/jneug/typst-mantys/assets/137803093/922db6b1-15e5-4a54-a667-ecec2841532d)

![image](https://github.com/jneug/typst-mantys/assets/137803093/e0cc43dc-8fa3-446d-bd49-567cfdbb757d)

This has the side effect of creating somewhat unblanced outlines for length 4.
![image](https://github.com/jneug/typst-mantys/assets/137803093/e2919f35-dcc2-488b-b873-ca3fbe9cb8aa)


Resolves #12.