### PR TITLE
Ensure dtypes state is array

### DIFF
--- a/src/api.typ
+++ b/src/api.typ
@@ -129,7 +129,7 @@
 
 
   context {
-    let custom-types = state("@mty-custom-types").final()
+    let custom-types = state("@mty-custom-types", ()).final()
     let color = auto
 
     let d = none


### PR DESCRIPTION
When no custom dtypes are added the state is `none`, this PR ensures that, where the state is read it will be an empty array in that case.

Alternatively, we could add the built-in types alongside how they are displayed (the colors and links to the API). Up to you if you prefer that approach, it comes with the upside of also being able to customize built-in colors.

Relate discussion: https://github.com/jneug/typst-mantys/issues/11#issuecomment-2084701237