### PR TITLE
Fix compilation issues due to deprecations and outdated dependencies in 0.15

### DIFF
--- a/src/_deps.typ
+++ b/src/_deps.typ
@@ -9,4 +9,4 @@
 #import "@preview/showybox:2.0.4"
 #import "@preview/codly:1.3.0"
 
-#import "@preview/octique:0.1.0"
+#import "@preview/octique:0.1.1"

--- a/src/api/commands.typ
+++ b/src/api/commands.typ
@@ -22,10 +22,10 @@
   name,
   /// Prefix to #arg[name].
   /// -> str | content | symbol
-  l: sym.angle.l,
+  l: sym.chevron.l,
   /// Prefix to #arg[name].
   /// -> str | content | symbol
-  r: sym.angle.r,
+  r: sym.chevron.r,
 ) = styles.meta(name, l: l, r: r)
 
 

--- a/src/core/styles.typ
+++ b/src/core/styles.typ
@@ -17,10 +17,10 @@
 
 
 // TODO: Use styles consistently
-#let arg = meta.with(l: sym.angle.l, r: sym.angle.r, kind: "arg")
+#let arg = meta.with(l: sym.chevron.l, r: sym.chevron.r, kind: "arg")
 
 
-#let sarg = meta.with(l: ".." + sym.angle.l, r: sym.angle.r, kind: "sarg")
+#let sarg = meta.with(l: ".." + sym.chevron.l, r: sym.chevron.r, kind: "sarg")
 
 
 #let barg = meta.with(l: sym.bracket.l, r: sym.bracket.r, kind: "barg")

--- a/src/themes/modern.typ
+++ b/src/themes/modern.typ
@@ -33,7 +33,7 @@
   fill: primary,
 )
 
-#import "@preview/gentle-clues:1.0.0"
+#import "@preview/gentle-clues:1.3.1"
 
 #let _alert-funcs = (
   "info": gentle-clues.info,


### PR DESCRIPTION
At fault are the following deprecations:
- within `mantys` directly:`sym.angle` should be replaced by `sym.chevron`.
- within dependencies: `octique` and `gentle-clues` need to be updated.